### PR TITLE
Disable rcmdcheck matcher since it misses filenames and line numbers

### DIFF
--- a/.github/workflows/standard_R_ci.yaml
+++ b/.github/workflows/standard_R_ci.yaml
@@ -52,6 +52,10 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
 
+      # disable rcmdcheck matcher since it misses filenames and line numbers
+      - run: |
+          echo ::remove-matcher owner=rcmdcheck::
+
       - uses: r-lib/actions/setup-pandoc@master
 
       - name: Query dependencies

--- a/.github/workflows/standard_R_ci.yaml
+++ b/.github/workflows/standard_R_ci.yaml
@@ -52,10 +52,6 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
 
-      # disable rcmdcheck matcher since it misses filenames and line numbers
-      - run: |
-          echo ::remove-matcher owner=rcmdcheck::
-
       - uses: r-lib/actions/setup-pandoc@master
 
       - name: Query dependencies
@@ -91,6 +87,10 @@ jobs:
           remotes::install_url("https://cran.r-project.org/src/contrib/Archive/playwith/playwith_0.9-54.tar.gz")
           remotes::install_deps(dependencies = TRUE)
         shell: Rscript {0}
+
+      # disable rcmdcheck matcher since it misses filenames and line numbers
+      - run: |
+          echo '::remove-matcher owner=rcmdcheck::'
 
       - name: Full check
         env:


### PR DESCRIPTION
Towards fixing #81.

We can use this ongoing, and rely on logs for test failures, or use it to build a better matcher.

### All Submissions:

* [x] Have you followed the guidelines in our **CONTRIBUTING** document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->


<!-- These have been added according to the rOpenSci guidelines. -->
<!-- From: https://www.talater.com/open-source-templates/#/page/99 -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue. List the bug ID if applicable)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing core functionality to change) 
- [x] Maintenance

Remainder N/A