### PR TITLE
Encourage contribs to use the GitHub auto-closing syntax

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -3,6 +3,12 @@
 * [ ] Have you followed the guidelines in our **CONTRIBUTING** document?
 * [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
 
+<!-- Does this resolve or supercede an open Issue or Pull Request?
+If so, write a line like Closes #12345 for each Issue or PR number that should be closed
+if this Pull Request is merged. -->
+
+Closes #xxxxx
+
 <!-- You can erase any parts of this template not applicable to your Pull Request. -->
 
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our **CONTRIBUTING** document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

This modifies the Pull Request template to request that a user specify if the PR resolves an open issue or PR. This helps trace an issue to its PR.