### PR TITLE
Change width to width.cutoff in print.hydromad

### DIFF
--- a/R/hydromad.R
+++ b/R/hydromad.R
@@ -194,7 +194,7 @@ print.hydromad <-
     if (!is.null(x$rfit)) {
       cat(
         "Routing fit spec.:",
-        toString(deparse(x$rfit, control = c(), width = 500),
+        toString(deparse(x$rfit, control = c(), width.cutoff = 500),
           width = getOption("width")
         ), "\n"
       )
@@ -210,7 +210,7 @@ print.hydromad <-
     if (length(x$info.rfit) > 0) {
       cat(
         "\nRouting fit info: ",
-        toString(deparse(x$info.rfit, control = c(), width = 500),
+        toString(deparse(x$info.rfit, control = c(), width.cutoff = 500),
           width = getOption("width")
         ), "\n"
       )


### PR DESCRIPTION
## R CMD Check: partial argument match of 'width' to 'width.cutoff'

This is the first of several small patches for getting those ticks to turn green in R CMD check, to address the error:

```
❯ checking R code for possible problems ... NOTE
  print.hydromad: warning in deparse(x$rfit, control = c(), width = 500):
    partial argument match of 'width' to 'width.cutoff'
  print.hydromad: warning in deparse(x$info.rfit, control = c(), width =
    500): partial argument match of 'width' to 'width.cutoff'
```

`width` is not an argument that `deparse()` accepts - this should be `width.cutoff`

[https://www.rdocumentation.org/packages/base/versions/3.6.2/topics/deparse](https://www.rdocumentation.org/packages/base/versions/3.6.2/topics/deparse)

### All Submissions:

* [x] Have you followed the guidelines in our **CONTRIBUTING** document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
