### PR TITLE
Fix printf and exit calls in fland1.c

### DIFF
--- a/src/fland1.c
+++ b/src/fland1.c
@@ -1,14 +1,14 @@
 #include "sacramento.h"
+#include <R.h>
+#include <R_ext/Print.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <R_ext/Print.h>
-#include <R.h>
 
 #define EPS 1.e-5 /* Minimum parameter value */
 
 void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
-
+  
   /* THIS SUBROUTINE EXECUTES THE SAC-SMA OPERATION FOR ONE
    * TIME PERIOD.
    ********************************************************
@@ -16,11 +16,11 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
    * ERIC ANDERSON - HRL     APRIL 1979     VERSION 1
    * MODIFIED FEB 1988 FOR RESEARCH ON THE U OF A CAMPUS */
   /*********************************************************/
-
+  
   /*  WRITTEN IN C. FROM FORTRAN CODE BY
    *  PATRICE O. YAPO 7/27/93  */
   /*  Last revised poy 2/20/94 */
-
+  
   int i, ninc;
   double edmnd, e1, e2, e3, e4, e5, red, uzrat, ratlzt, saved, ratlz;
   double del, twx, roimp, ssur, sif, sperc, sdro, spbf, sbf;
@@ -30,21 +30,21 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
   double percf, hpl, ratlp, ratls, fracp, percp, percs, excess;
   double sur, eused, tbf, bfcc, bfp, bfs, bfncc, tet;
   double rsum[7];
-
+  
   /*    REPARAMETERIZATION OPTION */
   /* izflag=2; reparameterized percolation,
    *           otherwise, original percolation */
   /* izflag = 1;
-     if (izflag == 2) aperc = sma->zperc;
-  */
-
+   if (izflag == 2) aperc = sma->zperc;
+   */
+  
   /*   if (iter1>=5050) printf("enter fland1\n");*/
-
+  
   zp = sma->zperc;
-
+  
   /* COMPUTE EVAPOTRANSPIRATION LOSS FOR THE TIME INTERVAL.
    * EDMND IS THE ET-DEMAND FOR THE TIME INTERVAL */
-
+  
   /* edmnd = sma->ep * sma->epdist; */ /* Compute et from upper zone */
   edmnd = sma->ep;
   e1 = edmnd * sma->uztwc / sma->uztwm;
@@ -54,97 +54,97 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
     sma->uztwc = 0.;
   e2 = 0.;
   if (sma->uztwc < 0.) { /* e1 cannot exceed sma->uztwc */
-    e1 += sma->uztwc;
+  e1 += sma->uztwc;
     sma->uztwc = 0.;
     red = edmnd - e1;
     ;
     if (sma->uzfwc < red) {
       e2 = sma->uzfwc; /* e2 is evap from sma->uzfwc */
-      sma->uzfwc = 0.;
-      red -= e2;
-      goto L225;
+  sma->uzfwc = 0.;
+  red -= e2;
+  goto L225;
     } else {
       e2 = red;
       sma->uzfwc -= e2;
       red = 0.;
     }
   }
-
+  
   /* UPPER ZONE FREE WATER RATIO EXCEEDS UPPER ZONE TENSION
    * WATER RATIO, THUS TRANSFER FREE WATER TO TENSION */
-
+  
   if ((sma->uztwc / sma->uztwm) < (sma->uzfwc / sma->uzfwm)) {
     uzrat = (sma->uztwc + sma->uzfwc) / (sma->uztwm + sma->uzfwm);
     sma->uztwc = sma->uztwm * uzrat;
     sma->uzfwc = sma->uzfwm * uzrat;
   }
-L225: /* This is a C label */
+  L225: /* This is a C label */
   e3 = red * sma->lztwc / (sma->uztwm + sma->lztwm);
   sma->lztwc -= e3;
   if (fabs(sma->lztwc) < EPS)
     sma->lztwc = 0.;
   if (sma->lztwc < 0.) {
     e3 += sma->lztwc; /* e3 cannot exceed sma->lztwc */
-    sma->lztwc = 0.;
+  sma->lztwc = 0.;
   }
   ratlzt = sma->lztwc / sma->lztwm;
   saved = sma->rserv * (sma->lzfpm + sma->lzfsm);
   ratlz = (sma->lztwc + sma->lzfpc + sma->lzfsc - saved) /
-          (sma->lztwm + sma->lzfpm + sma->lzfsm - saved);
-
+    (sma->lztwm + sma->lzfpm + sma->lzfsm - saved);
+  
   if (ratlzt < ratlz) { /* RESUPPLY LOWER ZONE TENSION
-                          WATER FROM LOWER ZONE FREE WATER
-                          IF MORE WATER AVAILABLE THERE. */
-    del = (ratlz - ratlzt) * sma->lztwm;
+   WATER FROM LOWER ZONE FREE WATER
+   IF MORE WATER AVAILABLE THERE. */
+  del = (ratlz - ratlzt) * sma->lztwm;
     /*    TRANSFER FROM sma->lzfsc to sma->lztwc */
     sma->lztwc = sma->lztwc + del;
-
+    
     sma->lzfsc = sma->lzfsc - del;
     if (sma->lzfsc < 0.) { /* IF TRANSFER EXCEEDS LZFSC THEN
-                         REMAINDER COMES FROM LZFPC */
-      sma->lzfpc += sma->lzfsc;
+     REMAINDER COMES FROM LZFPC */
+    sma->lzfpc += sma->lzfsc;
       sma->lzfsc = 0.;
     }
   }
-
+  
   /*   COMPUTE ET FROM ADIMP AREA.-E5 */
-
+  
   e5 = e1 +
-       (red + e2) * (sma->adimc - e1 - sma->uztwc) / (sma->uztwm + sma->lztwm);
-
+  (red + e2) * (sma->adimc - e1 - sma->uztwc) / (sma->uztwm + sma->lztwm);
+  
   /*    ADJUST ADIMC,ADDITIONAL IMPERVIOUS AREA STORAGE, FOR
    *    EVAPORATION */
-
+  
   sma->adimc -= e5;
   if (fabs(sma->adimc) < EPS)
     sma->adimc = 0.;
   if (sma->adimc < 0.) { /* E5 CAN NOT EXCEED ADIMC. */
-    e5 += sma->adimc;
+  e5 += sma->adimc;
     sma->adimc = 0.;
   }
   e5 *= sma->adimp;
-
+  
   /*    E5 IS ET FROM THE AREA ADIMP.
    *    COMPUTE PERCOLATION AND RUNOFF AMOUNTS. */
-
+  
   twx = sma->pxv + sma->uztwc - sma->uztwm;
   if (twx < 0.) { /* ALL MOISTURE HELD IN UZTW--NO EXCESS.  */
-    sma->uztwc += sma->pxv;
+  sma->uztwc += sma->pxv;
     twx = 0.;
   } else { /* MOISTURE AVAILABLE IN EXCESS OF UZTW STORAGE */
-    sma->uztwc = sma->uztwm;
+  sma->uztwc = sma->uztwm;
   }
   sma->adimc += (sma->pxv - twx);
-
+  
   /*    COMPUTE IMPERVIOUS AREA RUNOFF. */
   roimp = sma->pxv * sma->pctim;
-
+  
   /*    ROIMP IS RUNOFF FROM THE MINIMUM IMPERVIOUS AREA.  */
   fsum1->simpvt += roimp;
-
+  
   /*    INITIALIZE TIME INTERVAL SUMS. */
   sbf = ssur = sif = sperc = sdro = spbf = 0.0;
-
+  
   /*    DETERMINE COMPUTATIONAL TIME INCREMENTS FOR THE BASIC
    *    TIME INTERVAL */
   /*    NINC = NUMBER OF TIME INCREMENTS THAT THE TIME INTERVAL
@@ -153,17 +153,17 @@ L225: /* This is a C label */
    *    DINC = LENGTH OF EACH INCREMENT IN DAYS.
    *    PINC = AMOUNT OF AVAILABLE MOISTURE FOR EACH INCREMENT.
    *     ninc = (int) (1.0 + 0.2 * sma->uzfwc + twx);      */
-
+  
   ninc = (int)(1.0 + 0.2 * (sma->uzfwc + twx));
   if (ninc < sma->min_ninc)
     ninc = sma->min_ninc; // minimum number of loops
   dinc = 1.0 / (double)ninc * sma->dt;
   pinc = twx / (double)ninc;
-
+  
   /*    COMPUTE FREE WATER DEPLETION FRACTIONS FOR
    *    THE TIME INCREMENT BEING USED-BASIC DEPLETIONS
    *    ARE FOR ONE DAY */
-
+  
   if (sma->uzk > 1.)
     Rprintf("uzk = %f\n", sma->uzk);
   if (sma->lzpk > 1.)
@@ -174,20 +174,20 @@ L225: /* This is a C label */
   dlzp = 1.0 - pow((1.0 - sma->lzpk), dinc);
   dlzs = 1.0 - pow((1.0 - sma->lzsk), dinc);
   parea = 1.0 - sma->adimp - sma->pctim;
-
+  
   /*    START INCREMENTAL FOR LOOP FOR THE TIME INTERVAL.  */
   /*      if (iter1>=5050) printf("ninc=%d\n",ninc);*/
-
+  
   for (i = 0; i < ninc; i++) {
     adsur = 0.;
-
+    
     /*        COMPUTE DIRECT RUNOFF (FROM ADIMP AREA).
      *        ADDRO IS THE AMOUNT OF DIRECT RUNOFF FROM
      *        THE AREA ADIMP-SDRO IS THE SIX HOUR SUMMATION */
     ratio = (sma->adimc - sma->uztwc) / sma->lztwm;
     addro = pinc * (ratio * ratio);
     sdro += (addro * sma->adimp);
-
+    
     /*        COMPUTE BASEFLOW AND KEEP TRACK OF TIME INTERVAL SUM.  */
     bf = sma->lzfpc * dlzp;
     sma->lzfpc -= bf;
@@ -204,7 +204,7 @@ L225: /* This is a C label */
       sma->lzfsc = 0.0;
     }
     sbf += bf;
-
+    
     /*        COMPUTE PERCOLATION-IF NO WATER AVAILABLE THEN SKIP */
     if ((pinc + sma->uzfwc) <= 1.e-2) {
       sma->uzfwc += pinc;
@@ -212,16 +212,16 @@ L225: /* This is a C label */
     }
     percm = sma->lzfpm * dlzp + sma->lzfsm * dlzs;
     /*
-              if (izflag == 2) {
-                 zp = (sma->uzfwm - percm) / (percm * pow(aperc,sma->rexp));
-              }
-    */
+     if (izflag == 2) {
+     zp = (sma->uzfwm - percm) / (percm * pow(aperc,sma->rexp));
+     }
+     */
     if (zp < 0.0)
       zp = 0.0;
     perc = percm * sma->uzfwc / sma->uzfwm;
     /*        DEFR IS THE LOWER ZONE MOISTURE DEFICIENCY RATIO */
     defr = 1.0 - (sma->lztwc + sma->lzfpc + sma->lzfsc) /
-                     (sma->lztwm + sma->lzfpm + sma->lzfsm);
+      (sma->lztwm + sma->lzfpm + sma->lzfsm);
     if (defr < 0.) {
       Rprintf("defr = %f\n", defr);
       Rprintf("%f  %f  %f\n", sma->lztwc, sma->lzfpc, sma->lzfsc);
@@ -230,30 +230,30 @@ L225: /* This is a C label */
     }
     // uzdefr = 1.0 - (sma->uztwc + sma->uzfwc) / (sma->uztwm + sma->uzfwm);
     perc *= (1.0 + zp * pow(defr, sma->rexp));
-
+    
     /* NOTE...PERCOLATION OCCURS FROM UZFWC BEFORE PAV IS ADDED */
-
+    
     if (perc >= sma->uzfwc) { /* PERCOLATION RATE EXCEEDS UZFWC */
-      perc = sma->uzfwc;
+    perc = sma->uzfwc;
     }
     sma->uzfwc -= perc; /* PERCOLATION RATE IS LESS THAN UZFWC.  */
-
+    
     check = sma->lztwc + sma->lzfpc + sma->lzfsc + perc - sma->lztwm -
-            sma->lzfpm - sma->lzfsm;
+      sma->lzfpm - sma->lzfsm;
     if (check > 0.) { /* CHECK TO SEE IF PERCOLATION
-                       * EXCEEDS LOWER ZONE DEFICIENCY.  */
-      perc -= check;
+     * EXCEEDS LOWER ZONE DEFICIENCY.  */
+    perc -= check;
       sma->uzfwc += check;
     }
     /*        SPERC IS THE TIME INTERVAL SUMMATION OF PERC */
     sperc += perc;
-
+    
     /*        COMPUTE INTERFLOW AND KEEP TRACK OF TIME INTERVAL SUM.
      * NOTE...PINC HAS NOT YET BEEN ADDED */
     del = sma->uzfwc * duz;
     sif += del;
     sma->uzfwc -= del;
-
+    
     /*        DESCRIBE PERCOLATED WATER INTO THE LOWER ZONES
      *        TENSION WATER MUST BE FILLED FIRST EXCEPT FOR THE
      *        PFREE AREA.  PERCT IS PERCOLATION TO TENSION WATER
@@ -266,16 +266,16 @@ L225: /* This is a C label */
       percf = perct + sma->lztwc - sma->lztwm;
       sma->lztwc = sma->lztwm;
     }
-
+    
     /*        DISTRIBUTE PERCOLATION IN EXCESS OF TENSION
      *        REQUIREMENTS AMONG THE FREE WATER STORAGES */
     percf += (perc * sma->pfree);
     if (percf != 0.) {
-
+      
       /*           HPL IS THE RELATIVE SIZE OF THE PRIMARY STORAGE
        *           AS COMPARED WITH TOTAL LOWER ZONE FREE WATER STORAGE.  */
       hpl = sma->lzfpm / (sma->lzfpm + sma->lzfsm);
-
+      
       /*           RATLP AND RATLS ARE CONTENT TO CAPACITY RATIOS, OR
        *           IN OTHER WORDS, THE RELATIVE FULLNESS OF EACH STORAGE */
       ratlp = sma->lzfpc / sma->lzfpm;
@@ -284,7 +284,7 @@ L225: /* This is a C label */
       fracp = hpl * 2.0 * (1.0 - ratlp) / (1.0 - ratlp + 1.0 - ratls);
       if (fracp > 1.0)
         fracp = 1.0;
-
+      
       /*           PERCP AND PERCS ARE THE AMOUNT OF THE EXCESS
        *           PERCOLATION GOING TO PRIMARY AND SUPPLEMENTAL
        *           STORAGES, RESPECTIVELY. */
@@ -296,7 +296,7 @@ L225: /* This is a C label */
         sma->lzfsc = sma->lzfsm;
       }
       sma->lzfpc += (percf - percs);
-
+      
       /*           CHECK TO MAKE SURE LZFPC DOES NOT EXCEED LZFPM */
       if (sma->lzfpc > sma->lzfpm) {
         excess = sma->lzfpc - sma->lzfpm;
@@ -304,17 +304,17 @@ L225: /* This is a C label */
         sma->lzfpc = sma->lzfpm;
       }
     }
-
+    
     /*        DISTRIBUTE PINC BETWEEN UZFWC AND SURFACE RUNOFF. */
-
+    
     if (pinc != 0.) {
       if ((pinc + sma->uzfwc) <= sma->uzfwm) { /* CHECK IF PINC
-                                                * EXCEEDS UZFWM */
-        sma->uzfwc += pinc;                    /* NO SUFACE RUNOFF */
+     * EXCEEDS UZFWM */
+    sma->uzfwc += pinc;                    /* NO SUFACE RUNOFF */
       } else {
         sur = pinc + sma->uzfwc - sma->uzfwm;
         sma->uzfwc = sma->uzfwm;
-
+        
         /*              ADSUR IS THE AMOUNT OF SURFACE RUNOFF WHICH COMES
          *              FROM THAT PORTION OF ADIMP WHICH IS NOT
          *              CURRENTLY GENERATING DIRECT RUNOFF.  ADDRO/PINC
@@ -325,33 +325,33 @@ L225: /* This is a C label */
         ssur += (adsur * sma->adimp);
       }
     }
-  L249: /* C Label */
-    sma->adimc += (pinc - addro - adsur);
+    L249: /* C Label */
+        sma->adimc += (pinc - addro - adsur);
     if (sma->adimc > (sma->uztwm + sma->lztwm)) {
       addro += (sma->adimc - (sma->uztwm + sma->lztwm));
       sma->adimc = sma->uztwm + sma->lztwm;
     }
   } /* END OF INCREMENTAL FOR LOOP. */
-
-  /*   COMPUTE SUMS AND ADJUST RUNOFF AMOUNTS BY THE AREA OVER
-   *   WHICH THEY ARE GENERATED. */
-
-  /*    EUSED IS THE ET FROM PAREA WHICH IS 1.0-ADIMP-PCTIM */
-  eused = e1 + e2 + e3;
+        
+        /*   COMPUTE SUMS AND ADJUST RUNOFF AMOUNTS BY THE AREA OVER
+         *   WHICH THEY ARE GENERATED. */
+        
+        /*    EUSED IS THE ET FROM PAREA WHICH IS 1.0-ADIMP-PCTIM */
+        eused = e1 + e2 + e3;
   sif *= parea;
-
+  
   /*    SEPARATE CHANNEL COMPONENT OF BASEFLOW FROM THE
    *    NON-CHANNEL COMPONENT */
-
+  
   tbf = sbf * parea; /* TBF IS TOTAL BASEFLOW */
-                     /*    BFCC IS BASEFLOW, CHANNEL COMPONENT */
+  /*    BFCC IS BASEFLOW, CHANNEL COMPONENT */
   bfcc = tbf * (1.0 / (1.0 + sma->side));
   bfp = (spbf * parea) / (1.0 + sma->side);
   bfs = bfcc - bfp;
   if (bfs < 0.)
     bfs = 0;
   bfncc = tbf - bfcc; /* BFNCC IS BASEFLOW, NON-CHANNEL COMPONENT */
-
+  
   /*    ADD TO MONTHLY SUMS. */
   fsum1->sintft += sif;
   fsum1->sgwfp += bfp;
@@ -359,7 +359,7 @@ L225: /* This is a C label */
   fsum1->srecht += bfncc;
   fsum1->srost += ssur;
   fsum1->srodt += sdro;
-
+  
   /*    STORE EACH OF THE FIVE FLOWS IN VARIABLE TLCI_FLOWS*/ /* ADDED BY DPD */
   sma->tlci_flows[0] = roimp;                                 /* ADDED BY DPD */
   sma->tlci_flows[1] = sdro;                                  /* ADDED BY DPD */
@@ -368,22 +368,22 @@ L225: /* This is a C label */
   sma->tlci_flows[4] = bfp;                                   /* ADDED BY DPD */
   sma->tlci_flows[5] = bfs;                                   /* ADDED BY DPD */
   sma->tlci_flows[6] = bfcc;                                  /* ADDED BY DPD */
-
+  
   /*    COMPUTE TOTAL CHANNEL INFLOW FOR THE TIME INTERVAL.  */
   sma->tlci = roimp + sdro + ssur + sif + bfcc;
-
+  
   /*    COMPUTE E4-ET FROM RIPARIAN VEGETATION. */
   e4 = (edmnd - eused) * sma->riva;
-
+  
   /*    SUBTRACT E4 FROM CHANNEL INFLOW */
   sma->tlci -= e4;
-
+  
   if (sma->tlci < 0.) {
     e4 += sma->tlci;
     sma->tlci = 0.;
   }
   fsum1->srot += sma->tlci;
-
+  
   /*    COMPUTE TOTAL EVAPOTRANSPIRATION-TET */
   eused *= parea;
   tet = eused + e5 + e4;
@@ -392,11 +392,11 @@ L225: /* This is a C label */
   fsum1->se3 += (e3 * parea);
   fsum1->se4 += e4;
   fsum1->se5 += e5;
-
+  
   /*   CHECK THAT ADIMC >= UZTWC */
   if (sma->adimc < sma->uztwc)
     sma->adimc = sma->uztwc;
-
+  
   /*   ADD TO SUMS OF RUNOFF COMPONENTS. */
   rsum[0] += sma->tlci;
   rsum[1] += roimp;
@@ -405,7 +405,7 @@ L225: /* This is a C label */
   rsum[4] += sif;
   rsum[5] += bfs;
   rsum[6] += bfp;
-
+  
   /*      if (iter1>=5050) printf("end of fland1\n");*/
   /*      printf("end of fland\n");*/
   /*   END OF FUNCTION FLAND1 */

--- a/src/fland1.c
+++ b/src/fland1.c
@@ -8,6 +8,7 @@
 #define EPS 1.e-5 /* Minimum parameter value */
 
 void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
+  
   /* THIS SUBROUTINE EXECUTES THE SAC-SMA OPERATION FOR ONE
    * TIME PERIOD.
    ********************************************************

--- a/src/fland1.c
+++ b/src/fland1.c
@@ -1,9 +1,9 @@
 #include "sacramento.h"
+#include <R.h>
+#include <R_ext/Print.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <R_ext/Print.h>
-#include <R.h>
 
 #define EPS 1.e-5 /* Minimum parameter value */
 

--- a/src/fland1.c
+++ b/src/fland1.c
@@ -2,6 +2,8 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <R_ext/Print.h>
+#include <R.h>
 
 #define EPS 1.e-5 /* Minimum parameter value */
 
@@ -163,11 +165,11 @@ L225: /* This is a C label */
    *    ARE FOR ONE DAY */
 
   if (sma->uzk > 1.)
-    printf("uzk = %f\n", sma->uzk);
+    Rprintf("uzk = %f\n", sma->uzk);
   if (sma->lzpk > 1.)
-    printf("lzpk = %f\n", sma->lzpk);
+    Rprintf("lzpk = %f\n", sma->lzpk);
   if (sma->lzsk > 1.)
-    printf("lzsk = %f\n", sma->lzsk);
+    Rprintf("lzsk = %f\n", sma->lzsk);
   duz = 1.0 - pow((1.0 - sma->uzk), dinc);
   dlzp = 1.0 - pow((1.0 - sma->lzpk), dinc);
   dlzs = 1.0 - pow((1.0 - sma->lzsk), dinc);
@@ -221,10 +223,10 @@ L225: /* This is a C label */
     defr = 1.0 - (sma->lztwc + sma->lzfpc + sma->lzfsc) /
                      (sma->lztwm + sma->lzfpm + sma->lzfsm);
     if (defr < 0.) {
-      printf("defr = %f\n", defr);
-      printf("%f  %f  %f\n", sma->lztwc, sma->lzfpc, sma->lzfsc);
-      printf("%f  %f  %f\n", sma->lztwm, sma->lzfpm, sma->lzfsm);
-      exit(1);
+      Rprintf("defr = %f\n", defr);
+      Rprintf("%f  %f  %f\n", sma->lztwc, sma->lzfpc, sma->lzfsc);
+      Rprintf("%f  %f  %f\n", sma->lztwm, sma->lzfpm, sma->lzfsm);
+      error("error: lower zone moisture deficiency ratio is < 0.");
     }
     // uzdefr = 1.0 - (sma->uztwc + sma->uzfwc) / (sma->uztwm + sma->uzfwm);
     perc *= (1.0 + zp * pow(defr, sma->rexp));

--- a/src/fland1.c
+++ b/src/fland1.c
@@ -8,7 +8,6 @@
 #define EPS 1.e-5 /* Minimum parameter value */
 
 void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
-  
   /* THIS SUBROUTINE EXECUTES THE SAC-SMA OPERATION FOR ONE
    * TIME PERIOD.
    ********************************************************

--- a/src/fland1.c
+++ b/src/fland1.c
@@ -1,14 +1,14 @@
 #include "sacramento.h"
-#include <R.h>
-#include <R_ext/Print.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <R_ext/Print.h>
+#include <R.h>
 
 #define EPS 1.e-5 /* Minimum parameter value */
 
 void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
-  
+
   /* THIS SUBROUTINE EXECUTES THE SAC-SMA OPERATION FOR ONE
    * TIME PERIOD.
    ********************************************************
@@ -16,11 +16,11 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
    * ERIC ANDERSON - HRL     APRIL 1979     VERSION 1
    * MODIFIED FEB 1988 FOR RESEARCH ON THE U OF A CAMPUS */
   /*********************************************************/
-  
+
   /*  WRITTEN IN C. FROM FORTRAN CODE BY
    *  PATRICE O. YAPO 7/27/93  */
   /*  Last revised poy 2/20/94 */
-  
+
   int i, ninc;
   double edmnd, e1, e2, e3, e4, e5, red, uzrat, ratlzt, saved, ratlz;
   double del, twx, roimp, ssur, sif, sperc, sdro, spbf, sbf;
@@ -30,21 +30,21 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
   double percf, hpl, ratlp, ratls, fracp, percp, percs, excess;
   double sur, eused, tbf, bfcc, bfp, bfs, bfncc, tet;
   double rsum[7];
-  
+
   /*    REPARAMETERIZATION OPTION */
   /* izflag=2; reparameterized percolation,
    *           otherwise, original percolation */
   /* izflag = 1;
-   if (izflag == 2) aperc = sma->zperc;
-   */
-  
+     if (izflag == 2) aperc = sma->zperc;
+  */
+
   /*   if (iter1>=5050) printf("enter fland1\n");*/
-  
+
   zp = sma->zperc;
-  
+
   /* COMPUTE EVAPOTRANSPIRATION LOSS FOR THE TIME INTERVAL.
    * EDMND IS THE ET-DEMAND FOR THE TIME INTERVAL */
-  
+
   /* edmnd = sma->ep * sma->epdist; */ /* Compute et from upper zone */
   edmnd = sma->ep;
   e1 = edmnd * sma->uztwc / sma->uztwm;
@@ -54,97 +54,97 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
     sma->uztwc = 0.;
   e2 = 0.;
   if (sma->uztwc < 0.) { /* e1 cannot exceed sma->uztwc */
-  e1 += sma->uztwc;
+    e1 += sma->uztwc;
     sma->uztwc = 0.;
     red = edmnd - e1;
     ;
     if (sma->uzfwc < red) {
       e2 = sma->uzfwc; /* e2 is evap from sma->uzfwc */
-  sma->uzfwc = 0.;
-  red -= e2;
-  goto L225;
+      sma->uzfwc = 0.;
+      red -= e2;
+      goto L225;
     } else {
       e2 = red;
       sma->uzfwc -= e2;
       red = 0.;
     }
   }
-  
+
   /* UPPER ZONE FREE WATER RATIO EXCEEDS UPPER ZONE TENSION
    * WATER RATIO, THUS TRANSFER FREE WATER TO TENSION */
-  
+
   if ((sma->uztwc / sma->uztwm) < (sma->uzfwc / sma->uzfwm)) {
     uzrat = (sma->uztwc + sma->uzfwc) / (sma->uztwm + sma->uzfwm);
     sma->uztwc = sma->uztwm * uzrat;
     sma->uzfwc = sma->uzfwm * uzrat;
   }
-  L225: /* This is a C label */
+L225: /* This is a C label */
   e3 = red * sma->lztwc / (sma->uztwm + sma->lztwm);
   sma->lztwc -= e3;
   if (fabs(sma->lztwc) < EPS)
     sma->lztwc = 0.;
   if (sma->lztwc < 0.) {
     e3 += sma->lztwc; /* e3 cannot exceed sma->lztwc */
-  sma->lztwc = 0.;
+    sma->lztwc = 0.;
   }
   ratlzt = sma->lztwc / sma->lztwm;
   saved = sma->rserv * (sma->lzfpm + sma->lzfsm);
   ratlz = (sma->lztwc + sma->lzfpc + sma->lzfsc - saved) /
-    (sma->lztwm + sma->lzfpm + sma->lzfsm - saved);
-  
+          (sma->lztwm + sma->lzfpm + sma->lzfsm - saved);
+
   if (ratlzt < ratlz) { /* RESUPPLY LOWER ZONE TENSION
-   WATER FROM LOWER ZONE FREE WATER
-   IF MORE WATER AVAILABLE THERE. */
-  del = (ratlz - ratlzt) * sma->lztwm;
+                          WATER FROM LOWER ZONE FREE WATER
+                          IF MORE WATER AVAILABLE THERE. */
+    del = (ratlz - ratlzt) * sma->lztwm;
     /*    TRANSFER FROM sma->lzfsc to sma->lztwc */
     sma->lztwc = sma->lztwc + del;
-    
+
     sma->lzfsc = sma->lzfsc - del;
     if (sma->lzfsc < 0.) { /* IF TRANSFER EXCEEDS LZFSC THEN
-     REMAINDER COMES FROM LZFPC */
-    sma->lzfpc += sma->lzfsc;
+                         REMAINDER COMES FROM LZFPC */
+      sma->lzfpc += sma->lzfsc;
       sma->lzfsc = 0.;
     }
   }
-  
+
   /*   COMPUTE ET FROM ADIMP AREA.-E5 */
-  
+
   e5 = e1 +
-  (red + e2) * (sma->adimc - e1 - sma->uztwc) / (sma->uztwm + sma->lztwm);
-  
+       (red + e2) * (sma->adimc - e1 - sma->uztwc) / (sma->uztwm + sma->lztwm);
+
   /*    ADJUST ADIMC,ADDITIONAL IMPERVIOUS AREA STORAGE, FOR
    *    EVAPORATION */
-  
+
   sma->adimc -= e5;
   if (fabs(sma->adimc) < EPS)
     sma->adimc = 0.;
   if (sma->adimc < 0.) { /* E5 CAN NOT EXCEED ADIMC. */
-  e5 += sma->adimc;
+    e5 += sma->adimc;
     sma->adimc = 0.;
   }
   e5 *= sma->adimp;
-  
+
   /*    E5 IS ET FROM THE AREA ADIMP.
    *    COMPUTE PERCOLATION AND RUNOFF AMOUNTS. */
-  
+
   twx = sma->pxv + sma->uztwc - sma->uztwm;
   if (twx < 0.) { /* ALL MOISTURE HELD IN UZTW--NO EXCESS.  */
-  sma->uztwc += sma->pxv;
+    sma->uztwc += sma->pxv;
     twx = 0.;
   } else { /* MOISTURE AVAILABLE IN EXCESS OF UZTW STORAGE */
-  sma->uztwc = sma->uztwm;
+    sma->uztwc = sma->uztwm;
   }
   sma->adimc += (sma->pxv - twx);
-  
+
   /*    COMPUTE IMPERVIOUS AREA RUNOFF. */
   roimp = sma->pxv * sma->pctim;
-  
+
   /*    ROIMP IS RUNOFF FROM THE MINIMUM IMPERVIOUS AREA.  */
   fsum1->simpvt += roimp;
-  
+
   /*    INITIALIZE TIME INTERVAL SUMS. */
   sbf = ssur = sif = sperc = sdro = spbf = 0.0;
-  
+
   /*    DETERMINE COMPUTATIONAL TIME INCREMENTS FOR THE BASIC
    *    TIME INTERVAL */
   /*    NINC = NUMBER OF TIME INCREMENTS THAT THE TIME INTERVAL
@@ -153,17 +153,17 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
    *    DINC = LENGTH OF EACH INCREMENT IN DAYS.
    *    PINC = AMOUNT OF AVAILABLE MOISTURE FOR EACH INCREMENT.
    *     ninc = (int) (1.0 + 0.2 * sma->uzfwc + twx);      */
-  
+
   ninc = (int)(1.0 + 0.2 * (sma->uzfwc + twx));
   if (ninc < sma->min_ninc)
     ninc = sma->min_ninc; // minimum number of loops
   dinc = 1.0 / (double)ninc * sma->dt;
   pinc = twx / (double)ninc;
-  
+
   /*    COMPUTE FREE WATER DEPLETION FRACTIONS FOR
    *    THE TIME INCREMENT BEING USED-BASIC DEPLETIONS
    *    ARE FOR ONE DAY */
-  
+
   if (sma->uzk > 1.)
     Rprintf("uzk = %f\n", sma->uzk);
   if (sma->lzpk > 1.)
@@ -174,20 +174,20 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
   dlzp = 1.0 - pow((1.0 - sma->lzpk), dinc);
   dlzs = 1.0 - pow((1.0 - sma->lzsk), dinc);
   parea = 1.0 - sma->adimp - sma->pctim;
-  
+
   /*    START INCREMENTAL FOR LOOP FOR THE TIME INTERVAL.  */
   /*      if (iter1>=5050) printf("ninc=%d\n",ninc);*/
-  
+
   for (i = 0; i < ninc; i++) {
     adsur = 0.;
-    
+
     /*        COMPUTE DIRECT RUNOFF (FROM ADIMP AREA).
      *        ADDRO IS THE AMOUNT OF DIRECT RUNOFF FROM
      *        THE AREA ADIMP-SDRO IS THE SIX HOUR SUMMATION */
     ratio = (sma->adimc - sma->uztwc) / sma->lztwm;
     addro = pinc * (ratio * ratio);
     sdro += (addro * sma->adimp);
-    
+
     /*        COMPUTE BASEFLOW AND KEEP TRACK OF TIME INTERVAL SUM.  */
     bf = sma->lzfpc * dlzp;
     sma->lzfpc -= bf;
@@ -204,7 +204,7 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
       sma->lzfsc = 0.0;
     }
     sbf += bf;
-    
+
     /*        COMPUTE PERCOLATION-IF NO WATER AVAILABLE THEN SKIP */
     if ((pinc + sma->uzfwc) <= 1.e-2) {
       sma->uzfwc += pinc;
@@ -212,16 +212,16 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
     }
     percm = sma->lzfpm * dlzp + sma->lzfsm * dlzs;
     /*
-     if (izflag == 2) {
-     zp = (sma->uzfwm - percm) / (percm * pow(aperc,sma->rexp));
-     }
-     */
+              if (izflag == 2) {
+                 zp = (sma->uzfwm - percm) / (percm * pow(aperc,sma->rexp));
+              }
+    */
     if (zp < 0.0)
       zp = 0.0;
     perc = percm * sma->uzfwc / sma->uzfwm;
     /*        DEFR IS THE LOWER ZONE MOISTURE DEFICIENCY RATIO */
     defr = 1.0 - (sma->lztwc + sma->lzfpc + sma->lzfsc) /
-      (sma->lztwm + sma->lzfpm + sma->lzfsm);
+                     (sma->lztwm + sma->lzfpm + sma->lzfsm);
     if (defr < 0.) {
       Rprintf("defr = %f\n", defr);
       Rprintf("%f  %f  %f\n", sma->lztwc, sma->lzfpc, sma->lzfsc);
@@ -230,30 +230,30 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
     }
     // uzdefr = 1.0 - (sma->uztwc + sma->uzfwc) / (sma->uztwm + sma->uzfwm);
     perc *= (1.0 + zp * pow(defr, sma->rexp));
-    
+
     /* NOTE...PERCOLATION OCCURS FROM UZFWC BEFORE PAV IS ADDED */
-    
+
     if (perc >= sma->uzfwc) { /* PERCOLATION RATE EXCEEDS UZFWC */
-    perc = sma->uzfwc;
+      perc = sma->uzfwc;
     }
     sma->uzfwc -= perc; /* PERCOLATION RATE IS LESS THAN UZFWC.  */
-    
+
     check = sma->lztwc + sma->lzfpc + sma->lzfsc + perc - sma->lztwm -
-      sma->lzfpm - sma->lzfsm;
+            sma->lzfpm - sma->lzfsm;
     if (check > 0.) { /* CHECK TO SEE IF PERCOLATION
-     * EXCEEDS LOWER ZONE DEFICIENCY.  */
-    perc -= check;
+                       * EXCEEDS LOWER ZONE DEFICIENCY.  */
+      perc -= check;
       sma->uzfwc += check;
     }
     /*        SPERC IS THE TIME INTERVAL SUMMATION OF PERC */
     sperc += perc;
-    
+
     /*        COMPUTE INTERFLOW AND KEEP TRACK OF TIME INTERVAL SUM.
      * NOTE...PINC HAS NOT YET BEEN ADDED */
     del = sma->uzfwc * duz;
     sif += del;
     sma->uzfwc -= del;
-    
+
     /*        DESCRIBE PERCOLATED WATER INTO THE LOWER ZONES
      *        TENSION WATER MUST BE FILLED FIRST EXCEPT FOR THE
      *        PFREE AREA.  PERCT IS PERCOLATION TO TENSION WATER
@@ -266,16 +266,16 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
       percf = perct + sma->lztwc - sma->lztwm;
       sma->lztwc = sma->lztwm;
     }
-    
+
     /*        DISTRIBUTE PERCOLATION IN EXCESS OF TENSION
      *        REQUIREMENTS AMONG THE FREE WATER STORAGES */
     percf += (perc * sma->pfree);
     if (percf != 0.) {
-      
+
       /*           HPL IS THE RELATIVE SIZE OF THE PRIMARY STORAGE
        *           AS COMPARED WITH TOTAL LOWER ZONE FREE WATER STORAGE.  */
       hpl = sma->lzfpm / (sma->lzfpm + sma->lzfsm);
-      
+
       /*           RATLP AND RATLS ARE CONTENT TO CAPACITY RATIOS, OR
        *           IN OTHER WORDS, THE RELATIVE FULLNESS OF EACH STORAGE */
       ratlp = sma->lzfpc / sma->lzfpm;
@@ -284,7 +284,7 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
       fracp = hpl * 2.0 * (1.0 - ratlp) / (1.0 - ratlp + 1.0 - ratls);
       if (fracp > 1.0)
         fracp = 1.0;
-      
+
       /*           PERCP AND PERCS ARE THE AMOUNT OF THE EXCESS
        *           PERCOLATION GOING TO PRIMARY AND SUPPLEMENTAL
        *           STORAGES, RESPECTIVELY. */
@@ -296,7 +296,7 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
         sma->lzfsc = sma->lzfsm;
       }
       sma->lzfpc += (percf - percs);
-      
+
       /*           CHECK TO MAKE SURE LZFPC DOES NOT EXCEED LZFPM */
       if (sma->lzfpc > sma->lzfpm) {
         excess = sma->lzfpc - sma->lzfpm;
@@ -304,17 +304,17 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
         sma->lzfpc = sma->lzfpm;
       }
     }
-    
+
     /*        DISTRIBUTE PINC BETWEEN UZFWC AND SURFACE RUNOFF. */
-    
+
     if (pinc != 0.) {
       if ((pinc + sma->uzfwc) <= sma->uzfwm) { /* CHECK IF PINC
-     * EXCEEDS UZFWM */
-    sma->uzfwc += pinc;                    /* NO SUFACE RUNOFF */
+                                                * EXCEEDS UZFWM */
+        sma->uzfwc += pinc;                    /* NO SUFACE RUNOFF */
       } else {
         sur = pinc + sma->uzfwc - sma->uzfwm;
         sma->uzfwc = sma->uzfwm;
-        
+
         /*              ADSUR IS THE AMOUNT OF SURFACE RUNOFF WHICH COMES
          *              FROM THAT PORTION OF ADIMP WHICH IS NOT
          *              CURRENTLY GENERATING DIRECT RUNOFF.  ADDRO/PINC
@@ -325,33 +325,33 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
         ssur += (adsur * sma->adimp);
       }
     }
-    L249: /* C Label */
-        sma->adimc += (pinc - addro - adsur);
+  L249: /* C Label */
+    sma->adimc += (pinc - addro - adsur);
     if (sma->adimc > (sma->uztwm + sma->lztwm)) {
       addro += (sma->adimc - (sma->uztwm + sma->lztwm));
       sma->adimc = sma->uztwm + sma->lztwm;
     }
   } /* END OF INCREMENTAL FOR LOOP. */
-        
-        /*   COMPUTE SUMS AND ADJUST RUNOFF AMOUNTS BY THE AREA OVER
-         *   WHICH THEY ARE GENERATED. */
-        
-        /*    EUSED IS THE ET FROM PAREA WHICH IS 1.0-ADIMP-PCTIM */
-        eused = e1 + e2 + e3;
+
+  /*   COMPUTE SUMS AND ADJUST RUNOFF AMOUNTS BY THE AREA OVER
+   *   WHICH THEY ARE GENERATED. */
+
+  /*    EUSED IS THE ET FROM PAREA WHICH IS 1.0-ADIMP-PCTIM */
+  eused = e1 + e2 + e3;
   sif *= parea;
-  
+
   /*    SEPARATE CHANNEL COMPONENT OF BASEFLOW FROM THE
    *    NON-CHANNEL COMPONENT */
-  
+
   tbf = sbf * parea; /* TBF IS TOTAL BASEFLOW */
-  /*    BFCC IS BASEFLOW, CHANNEL COMPONENT */
+                     /*    BFCC IS BASEFLOW, CHANNEL COMPONENT */
   bfcc = tbf * (1.0 / (1.0 + sma->side));
   bfp = (spbf * parea) / (1.0 + sma->side);
   bfs = bfcc - bfp;
   if (bfs < 0.)
     bfs = 0;
   bfncc = tbf - bfcc; /* BFNCC IS BASEFLOW, NON-CHANNEL COMPONENT */
-  
+
   /*    ADD TO MONTHLY SUMS. */
   fsum1->sintft += sif;
   fsum1->sgwfp += bfp;
@@ -359,7 +359,7 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
   fsum1->srecht += bfncc;
   fsum1->srost += ssur;
   fsum1->srodt += sdro;
-  
+
   /*    STORE EACH OF THE FIVE FLOWS IN VARIABLE TLCI_FLOWS*/ /* ADDED BY DPD */
   sma->tlci_flows[0] = roimp;                                 /* ADDED BY DPD */
   sma->tlci_flows[1] = sdro;                                  /* ADDED BY DPD */
@@ -368,22 +368,22 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
   sma->tlci_flows[4] = bfp;                                   /* ADDED BY DPD */
   sma->tlci_flows[5] = bfs;                                   /* ADDED BY DPD */
   sma->tlci_flows[6] = bfcc;                                  /* ADDED BY DPD */
-  
+
   /*    COMPUTE TOTAL CHANNEL INFLOW FOR THE TIME INTERVAL.  */
   sma->tlci = roimp + sdro + ssur + sif + bfcc;
-  
+
   /*    COMPUTE E4-ET FROM RIPARIAN VEGETATION. */
   e4 = (edmnd - eused) * sma->riva;
-  
+
   /*    SUBTRACT E4 FROM CHANNEL INFLOW */
   sma->tlci -= e4;
-  
+
   if (sma->tlci < 0.) {
     e4 += sma->tlci;
     sma->tlci = 0.;
   }
   fsum1->srot += sma->tlci;
-  
+
   /*    COMPUTE TOTAL EVAPOTRANSPIRATION-TET */
   eused *= parea;
   tet = eused + e5 + e4;
@@ -392,11 +392,11 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
   fsum1->se3 += (e3 * parea);
   fsum1->se4 += e4;
   fsum1->se5 += e5;
-  
+
   /*   CHECK THAT ADIMC >= UZTWC */
   if (sma->adimc < sma->uztwc)
     sma->adimc = sma->uztwc;
-  
+
   /*   ADD TO SUMS OF RUNOFF COMPONENTS. */
   rsum[0] += sma->tlci;
   rsum[1] += roimp;
@@ -405,7 +405,7 @@ void fland1(struct SMA *sma, struct FSUM1 *fsum1) {
   rsum[4] += sif;
   rsum[5] += bfs;
   rsum[6] += bfp;
-  
+
   /*      if (iter1>=5050) printf("end of fland1\n");*/
   /*      printf("end of fland\n");*/
   /*   END OF FUNCTION FLAND1 */


### PR DESCRIPTION
## Patch: issue 70 fix

R CMD check is currently returning this error:

```
 * checking compiled code ... WARNING
##[warning]File ‘hydromad/libs/hydromad.so’:
  Found ‘__printf_chk’, possibly from ‘printf’ (C)
    Object: ‘fland1.o’
  Found ‘exit’, possibly from ‘exit’ (C)
    Object: ‘fland1.o’

Compiled code should not call entry points which might terminate R nor
write to stdout/stderr instead of to the console, nor use Fortran I/O
nor system RNGs.
```

Calling `printf` and `exit` are not advised when writing C code. `Rprintf` should be used in place of `printf` (now changed). `exit` will terminate a user's R process, so this has been changed to `error` instead and now includes an  message - please let me know if you think this message could be improved!

Helpful resources:
[https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Printing](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Printing)
[https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Error-signaling](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Error-signaling)

### All Submissions:

* [x] Have you followed the guidelines in our **CONTRIBUTING** document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- Does this resolve or supercede an open Issue or Pull Request?
If so, write a line like Closes #12345 for each Issue or PR number that should be closed
if this Pull Request is merged. -->

Closes #70 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->


<!-- These have been added according to the rOpenSci guidelines. -->
<!-- From: https://www.talater.com/open-source-templates/#/page/99 -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. List the bug ID if applicable)
