### PR TITLE
Fix update.hydromad.R

### DIFF
--- a/R/update.hydromad.R
+++ b/R/update.hydromad.R
@@ -15,7 +15,7 @@ update.hydromad <-
         stop("elements of 'newpars' must be named")
       }
       ccall <- match.call()
-      ccall[[1]] <- quote(hydromad:::update.hydromad)
+      ccall[[1]] <- quote(update)
       ccall <- as.call(modifyList(
         as.list(ccall),
         as.list(newpars)


### PR DESCRIPTION
# Fix update.hydromad.R

This PR is to address a Note in R CMD check that returns:

```
 There are ::: calls to the package's namespace in its code. A package
  almost never needs to use ::: for its own objects:
  ‘update.hydromad’
```

`ccall[[1]] <- quote(hydromad:::update.hydromad)`

has been replaced with

`ccall[[1]] <- quote(update)`

which has appeared to fix the problem.

### All Submissions:

* [x] Have you followed the guidelines in our **CONTRIBUTING** document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- Does this resolve or supercede an open Issue or Pull Request?
If so, write a line like Closes #12345 for each Issue or PR number that should be closed
if this Pull Request is merged. -->

Closes #136

<!-- You can erase any parts of this template not applicable to your Pull Request. -->


<!-- These have been added according to the rOpenSci guidelines. -->
<!-- From: https://www.talater.com/open-source-templates/#/page/99 -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. List the bug ID if applicable)

### Changes to Core Features:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Have you successfully run tests with your changes locally?