### PR TITLE
Add skip_on_ci() to test-statistics.R

### DIFF
--- a/tests/testthat/test-statistics.R
+++ b/tests/testthat/test-statistics.R
@@ -78,5 +78,6 @@ test_that("formula works within functions", {
   # Formula is less than 10% slower
   time.fun <- system.time(replicate(1e3, objFunVal(modx, hmadstat("r.squared"))))
   time.formula <- system.time(replicate(1e3, objFunVal(modx, ~ hmadstat("r.squared")(Q, X, ...))))
+  skip_on_ci()
   expect_lt((time.formula[3] - time.fun[3]) / time.fun[3], 0.1)
 })

--- a/tests/testthat/test-statistics.R
+++ b/tests/testthat/test-statistics.R
@@ -76,8 +76,8 @@ test_that("formula works within functions", {
   expect_equal(formula.in.function(), objFunVal(modx, hmadstat("r.squared")))
 
   # Formula is less than 10% slower
+  skip_on_ci()
   time.fun <- system.time(replicate(1e3, objFunVal(modx, hmadstat("r.squared"))))
   time.formula <- system.time(replicate(1e3, objFunVal(modx, ~ hmadstat("r.squared")(Q, X, ...))))
-  skip_on_ci()
   expect_lt((time.formula[3] - time.fun[3]) / time.fun[3], 0.1)
 })


### PR DESCRIPTION
## Add skip_on_ci() to test-statistics.R

The addition of `skip_on_ci()` should hopefully skip lines 80 - 82 when R CMD check is conducted on GitHub (will check the action logs once this PR is opened). Can confirm that 80 - 82 are still run during local checks.

### All Submissions:

* [x] Have you followed the guidelines in our **CONTRIBUTING** document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- Does this resolve or supercede an open Issue or Pull Request?
If so, write a line like Closes #12345 for each Issue or PR number that should be closed
if this Pull Request is merged. -->

Closes #143

<!-- You can erase any parts of this template not applicable to your Pull Request. -->


<!-- These have been added according to the rOpenSci guidelines. -->
<!-- From: https://www.talater.com/open-source-templates/#/page/99 -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix 