### PR TITLE
Workflow tweaks

### DIFF
--- a/.github/workflows/roxygenise.yml
+++ b/.github/workflows/roxygenise.yml
@@ -1,11 +1,6 @@
 on:
-  push:
-    branches:
-      - master
-      - workflow-tweaks
-  pull_request:
-    branches:
-      - master
+  issue_comment:
+    types: [created]
 
 name: roxygenise
 

--- a/.github/workflows/roxygenise.yml
+++ b/.github/workflows/roxygenise.yml
@@ -1,0 +1,35 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+name: roxygenise
+jobs:
+  document:
+    if: startsWith(github.event.comment.body, '/document')
+    name: document
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: r-lib/actions/pr-fetch@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: r-lib/actions/setup-r@master
+      - name: Install dependencies
+        run: Rscript -e 'install.packages(c("remotes", "roxygen2"))' -e 'remotes::install_deps(dependencies = TRUE)'
+      - name: Document
+        run: Rscript -e 'roxygen2::roxygenise()'
+      - name: commit
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          git add man/\* NAMESPACE
+          git commit -m 'Document'
+      - uses: r-lib/actions/pr-push@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/roxygenise.yml
+++ b/.github/workflows/roxygenise.yml
@@ -2,11 +2,13 @@ on:
   push:
     branches:
       - master
+      - workflow-tweaks
   pull_request:
     branches:
       - master
 
 name: roxygenise
+
 jobs:
   document:
     if: startsWith(github.event.comment.body, '/document')
@@ -14,16 +16,29 @@ jobs:
     runs-on: macOS-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - uses: actions/checkout@v2
+        
       - uses: r-lib/actions/pr-fetch@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: r-lib/actions/setup-r@master
+        
       - name: Install dependencies
-        run: Rscript -e 'install.packages(c("remotes", "roxygen2"))' -e 'remotes::install_deps(dependencies = TRUE)'
+        run: |
+          remotes::install_cran("rcmdcheck")
+          remotes::install_cran("Rcpp")
+          remotes::install_cran("coda")
+          remotes::install_github("TillF/ppso")
+          remotes::install_github("roxygen2")
+          remotes::install_url("http://download.r-forge.r-project.org/src/contrib/dream_0.4-2.tar.gz")
+          remotes::install_deps(dependencies = TRUE)
+
       - name: Document
         run: Rscript -e 'roxygen2::roxygenise()'
+        
       - name: commit
         run: |
           git config --local user.email "actions@github.com"

--- a/.github/workflows/standard_R_ci.yaml
+++ b/.github/workflows/standard_R_ci.yaml
@@ -79,7 +79,6 @@ jobs:
         shell: Rscript {0}
 
       - name: Full check
-        if: runner.os == 'macOS'
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
         run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
@@ -91,14 +90,6 @@ jobs:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
           _R_CHECK_FORCE_SUGGESTS_: false
         run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Check without tests and examples
-        if: runner.os == 'Windows'
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-          _R_CHECK_FORCE_SUGGESTS_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran", "--no-examples", "--no-tests"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
 
       - name: Upload check results

--- a/.github/workflows/standard_R_ci.yaml
+++ b/.github/workflows/standard_R_ci.yaml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: macOS-latest, r: "devel" }
           - { os: macOS-latest, r: "release" }
           - { os: windows-latest, r: "release" }
           - {


### PR DESCRIPTION
## Workflow tweaks

In this PR:

- macOS R devel has been taken out of the matrix as it isn't currently building properly as mentioned in #127 ... this can be added back later once you see that it's running on other R GitHub repos.
- R CMD check now runs in either its full glory or without optional packages (the no tests / no examples version has been taken out). I was hoping to make a duplicate copy of an OS and assign it to run w/o the optional packages, but my efforts have been thwarted because I haven't found any documentation on how to assign names to elements of the job matrix ... so I currently have Windows running both checks. Suggestions are welcome.
- A roxygenise GitHub action has been added to ensure that the documentation stays up to date with any changes to the .R files #152. It requires a secret token: [https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)


### All Submissions:

* [x] Have you followed the guidelines in our **CONTRIBUTING** document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- Does this resolve or supercede an open Issue or Pull Request?
If so, write a line like Closes #12345 for each Issue or PR number that should be closed
if this Pull Request is merged. -->

Closes #152 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
