### PR TITLE
Recommend changing repos in options rather than install.packages

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -35,20 +35,19 @@ The website describes the different functions and gives examples of the code app
 install.packages("hydromad")
 ```
 --->
-* Install required packages from within R:
-``` r
-install.packages(c("zoo", "latticeExtra", "polynom", "car", "Hmisc","reshape"))
-``` 
-
+* Add the `hydromad` repository:
+```r
+options(repos=c("http://hydromad.catchment.org",getOption("repos")))
+```
 * Install hydromad:
 ``` r
-install.packages("hydromad", repos="http://hydromad.catchment.org")
+install.packages("hydromad")
 ``` 
 
 * Optionally install other packages required for certain functions:
 ``` r
 install.packages("DEoptim")
-install.packages("dream", repos="http://hydromad.catchment.org")
+install.packages("dream")
 ``` 
 
 Once it is installed, get started with

--- a/README.Rmd
+++ b/README.Rmd
@@ -35,7 +35,7 @@ The website describes the different functions and gives examples of the code app
 install.packages("hydromad")
 ```
 --->
-* Add the `hydromad` repository:
+* Add the `hydromad` repository for this R session:
 ```r
 options(repos=c("http://hydromad.catchment.org",getOption("repos")))
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ install.packages("hydromad")
 ```
 --->
 
--   Add the `hydromad` repository:
+-   Add the `hydromad` repository for this R session:
 
 <!-- -->
 

--- a/README.md
+++ b/README.md
@@ -36,24 +36,24 @@ install.packages("hydromad")
 ```
 --->
 
--   Install required packages from within R:
+-   Add the `hydromad` repository:
 
 <!-- -->
 
-    install.packages(c("zoo", "latticeExtra", "polynom", "car", "Hmisc","reshape"))
+    options(repos=c("http://hydromad.catchment.org",getOption("repos")))
 
 -   Install hydromad:
 
 <!-- -->
 
-    install.packages("hydromad", repos="http://hydromad.catchment.org")
+    install.packages("hydromad")
 
 -   Optionally install other packages required for certain functions:
 
 <!-- -->
 
     install.packages("DEoptim")
-    install.packages("dream", repos="http://hydromad.catchment.org")
+    install.packages("dream")
 
 Once it is installed, get started with
 


### PR DESCRIPTION
This allow install.packages to search for packages in multiple repos and avoids errors about packages not being available.
It also future-proofs against changes to dependencies by allowing the DESCRIPTION file to be the sole source of necessary packages (DRY).

### All Submissions:

* [x] Have you followed the guidelines in our **CONTRIBUTING** document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

Closes #40 


### Changes to Core Features:
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
* [ ] Does your code run on all major platforms (Windows, macOS, Linux)? - should do, but I have only tested on windows
* [x] Have you demonstrated backwards compatibility and compatibility with the current development version, or discussed a potential break in backwards compatibility?
* [x] Have you updated the package vignettes? - already avoids specific installation instructions
