### PR TITLE
Tests for date formats, with conversion for POSIXlt

### DIFF
--- a/R/hydromad.R
+++ b/R/hydromad.R
@@ -114,6 +114,13 @@ hydromad <-
     ## create the model object
     obj <- list(call = match.call())
     class(obj) <- "hydromad"
+    
+    # DATA validation
+    if(is.zoo(DATA) && "POSIXlt" %in% class(index(DATA))){
+      index(DATA)<-chron::as.chron(index(DATA))
+      warning("POSIXlt index converted with as.chron")
+    }
+    
     ## dots `...` may contain arguments for sma and/or routing.
     ## update() takes default parameter ranges/values from hydromad.options().
     obj$parlist <- list()

--- a/tests/testthat/test-data-formats.R
+++ b/tests/testthat/test-data-formats.R
@@ -1,0 +1,51 @@
+library(testthat)
+library(hydromad)
+library(patrick)
+
+with_parameters_test_that(
+  "zoo and hydromad handle date format: ",
+  {
+    if (!is.null(will_warn) && will_warn) {
+      wrapper <- suppressWarnings
+    } else {
+      wrapper <- identity
+    }
+    
+    DATA <- data.frame(
+      P = c(100, rep(0, 9)),
+      E = 20
+    )
+
+    DATA <- zoo(DATA, order.by = date)
+    wrapper(expect_equal(nrow(as.ts(DATA)), 10))
+
+    mod <- wrapper(hydromad(
+      DATA,
+      sma = "cwi",
+      tw = 32, f = 2, scale = 0.01,
+      routing = "expuh",
+      tau_s = 1,
+      warmup = 0
+    ))
+    Q <- c(
+      63.2120558828558, 23.254415793483, 8.55482148687488,
+      3.14714294791298, 1.15776918896487, 0.425919482241911, 0.156687021111184,
+      0.0576419337652005, 0.0212052823815832, 0.00780098743241947
+    )
+    expect_equal(coredata(fitted(mod)), Q)
+  },
+  cases(
+    `ymd` = list(date = sprintf("2020-01-%d", 1:10), will_warn = TRUE),
+    `Date` = list(date = as.Date(sprintf("2020-01-%d", 1:10))),
+    `POSIXct` = list(
+      date = as.POSIXct(sprintf("2020-01-%d 3:00", 1:10), tz = "GMT"),
+      will_warn = TRUE
+    ),
+    `POSIXct hourly` = list(
+      date = as.POSIXct(sprintf("2020-01-01 %0d:00", 1:10), tz = "GMT"),
+      will_warn = TRUE
+    ),
+    `POSIXlt` = list(date = as.POSIXlt(sprintf("2020-01-%d 3:00", 1:10), tz = "GMT"),will_warn = TRUE),
+    `chron` = list(date = chron::as.chron(sprintf("2020-01-%d 3:00", 1:10)))
+  )
+)


### PR DESCRIPTION
It turns out chron conversion is only necessary for POSIXlt according to these tests,  and conversion is therefore added to the hydromad constructor.

### All Submissions:

* [x ] Have you followed the guidelines in our **CONTRIBUTING** document?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

Closes #31

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

1. [x] Have you ensured there are no conflicts with major packages (e.g. tidyverse, MASS) or base R packages?
2. [x] Does your new feature require documentation, and if so, have you updated the documentation? - simply avoids an error
3. [x] Have you added tests for your features, and do your features pass all tests?
4. [x] Have you linted your code with lintr locally prior to submission?
5. [x] Have you styled your code with styler locally prior to submission?



### Changes to Core Features:
* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you added tests for your core features and do your core features pass all tests?
* [x] Have you successfully run tests with your changes locally?
* [ ] Does your code run on all major platforms (Windows, macOS, Linux)?
* [x] Have you demonstrated backwards compatibility and compatibility with the current development version, or discussed a potential break in backwards compatibility?
