### PR TITLE
Fix warmup parameter is ignored when using rfit #169

### DIFF
--- a/R/routingfit.R
+++ b/R/routingfit.R
@@ -19,6 +19,9 @@ doRoutingFit <-
     if (!is.list(rfit)) {
       rfit <- list(rfit)
     }
+    if(!is.null(object$warmup)){
+      rfit$warmup <- object$warmup
+    }
     ## ok, 'rfit' given, fit the routing model.
     ## we should remove any existing routing parameters
     object$parlist <- as.list(coef(object, which = "sma", warn = FALSE, etc = TRUE))

--- a/tests/testthat/test-with-exact-inputs.R
+++ b/tests/testthat/test-with-exact-inputs.R
@@ -34,6 +34,15 @@ test_that("rfit methods work on (2,1) model with exact inputs", {
   expect_gt(summary(fits$inv)$r.squared, 0.9999)
 })
 
+test_that("routingFit works on short time series with shorter warmup", {
+  xspec_short <- update(xspec,
+    newdata = xspec$data[10:40, ],
+    warmup = 0,
+    rfit = list("ls", order = c(n = 2, m = 1))
+  )
+  expect_gt(summary(xspec_short)$r.squared, 0.98)
+})
+
 U <- fitted(xspec, U = TRUE, all = TRUE)
 
 Q_n0m0 <- expuh.sim(U, pars = n0m0)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our **CONTRIBUTING** document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

Closes #169 by setting warmup on rfit when calling doRoutingFit
If not specified, warmup is still taken from hydromad.getOption("warmup").
The expected behaviour when warmup is set in a hydromad object is for it to apply to all routing methods, which this change does.
The rfit object is passed to the doRfit function, the arguments to which are passed to the specified routing function https://github.com/josephguillaume/hydromad/blob/5d7f0247403c5e7e0a33f81d4795da73d6ecf506/R/routingfit.R#L61

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue. List the bug ID if applicable)

### Changes to Core Features:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you added tests for your core features and do your core features pass all tests?
* [x] Have you successfully run tests with your changes locally?
* [ ] Does your code run on all major platforms (Windows, macOS, Linux)?
* [x] Have you demonstrated backwards compatibility and compatibility with the current development version, or discussed a potential break in backwards compatibility?
